### PR TITLE
Ensure falsy ids don't count as being a defined id in memory engine.

### DIFF
--- a/lib/memory-engine.js
+++ b/lib/memory-engine.js
@@ -52,7 +52,8 @@ module.exports = function(options) {
     callback = callback || emptyFn
     // clone the object
     object = extend({}, object)
-    if (object[options.idProperty] === undefined) {
+    if (!object[options.idProperty]) {
+
       idSeq += 1
       object[options.idProperty] = idSeq
       data[idSeq] = object

--- a/test/engine.tests.js
+++ b/test/engine.tests.js
@@ -116,6 +116,24 @@ module.exports = function(idProperty, getEngine, beforeCallback, afterCallback) 
         })
       })
 
+      it('should not count falsy values as being a defined id', function(done) {
+
+        function checkFalsy(falsy, cb) {
+          var original = {}
+          original[idProperty] = falsy
+
+          getEngine(function(error, engine) {
+            should.not.exist(error)
+            engine.create(original, function(error, entity) {
+              should.notEqual(entity[idProperty], falsy)
+              cb()
+            })
+          })
+        }
+
+        async.forEach([null, undefined, '', false, 0, NaN], checkFalsy, done)
+      })
+
       it('should not retain reference to original object', function(done) {
 
         var item = { a: 1 }


### PR DESCRIPTION
Currently in the memory engine any falsy value (apart from `undefined`) that gets passed to create gets set as the `_id` value.

The fix just checks if the value is falsy as opposed to checking `undefined`.
