### PR TITLE
Fixed replacing _id property when using the memory engine

### DIFF
--- a/lib/memory-engine.js
+++ b/lib/memory-engine.js
@@ -11,7 +11,7 @@ module.exports = function (opts) {
     , idSeq = 0
 
   var options = opts || {}
-  _.extend(options, defaults)
+  _.extend(defaults, options)
 
   /**
    * Checks that the object has the ID property present, then checks


### PR DESCRIPTION
idProperty option was not taking effect when using the memory engine, such a simple error but cost me 2 hours at a hackathon thinking it was something that I was doing :)
