### PR TITLE
Add done fn to #idProperty tests

### DIFF
--- a/test/engine.tests.js
+++ b/test/engine.tests.js
@@ -28,15 +28,17 @@ module.exports = function (idProperty, getEngine, beforeCallback, afterCallback)
     })
 
     describe('#idProperty', function () {
-      it('should return name of the idProperty', function () {
+      it('should return name of the idProperty', function (done) {
         getEngine(function (error, engine) {
           engine.idProperty.should.eql('_id')
+          done()
         })
       })
 
-      it('should should be able to change the idProperty', function () {
+      it('should should be able to change the idProperty', function (done) {
         getEngine({ idProperty: 'hello' }, function (error, engine) {
           engine.idProperty.should.eql('hello')
+          done()
         })
       })
     })


### PR DESCRIPTION
Required to alleviate intermittent test failures if either of the #idProperty tests fail.
