### PR TITLE
Expose `idType` in memory engine

### DIFF
--- a/lib/memory-engine.js
+++ b/lib/memory-engine.js
@@ -283,6 +283,16 @@ module.exports = function (opts) {
     })
   }
 
+  /**
+   * Casts an id to the type required by the database
+   *
+   * @param {String} the value to cast
+   * @api public
+   */
+  function idType(value) {
+    return value
+  }
+
   extend(self
     , { create: create
       , read: read
@@ -294,6 +304,7 @@ module.exports = function (opts) {
       , count: count
       , idProperty: options.idProperty
       , createOrUpdate: createOrUpdate
+      , idType: idType
       })
 
   return self

--- a/test/engine.tests.js
+++ b/test/engine.tests.js
@@ -28,6 +28,7 @@ module.exports = function (idProperty, getEngine, beforeCallback, afterCallback)
       , './count'
       , './create-or-update'
       , './streaming'
+      , './id-type'
        ].map(function(testFile) {
         require(testFile)(idProperty, getEngine)
       })

--- a/test/id-type.js
+++ b/test/id-type.js
@@ -1,0 +1,14 @@
+var assert = require('assert')
+
+module.exports = function(idProperty, getEngine) {
+
+  describe('#idType()', function () {
+    it('should return a function', function (done) {
+      getEngine(function (error, engine) {
+        assert.equal(typeof engine.idType, 'function')
+        done()
+      })
+    })
+  })
+
+}


### PR DESCRIPTION
Without this, the API between memory-backed services have a
different API to `save-mongodb` services, which can cause test
failures.