### PR TITLE
Add support for `limit` option in memory engine (fixes #32)

### DIFF
--- a/lib/memory-engine.js
+++ b/lib/memory-engine.js
@@ -229,9 +229,9 @@ module.exports = function (opts) {
     }
 
     var cursor = Mingo.find(data, query, options && options.fields)
-    if (options && options.sort) {
-      cursor = cursor.sort(options.sort)
-    }
+    if (options && options.sort) cursor = cursor.sort(options.sort)
+    if (options && options.limit) cursor = cursor.limit(options.limit)
+
     var allData = getObjectCopies(cursor.all())
 
     if (callback === undefined) {

--- a/test/find.js
+++ b/test/find.js
@@ -185,7 +185,7 @@ module.exports = function(idProperty, getEngine) {
       })
     })
 
-    it('should support { limit: {} } property in options', function (done) {
+    it('should support { limit: n } property in options', function (done) {
       getEngine(function (error, engine) {
         async.map([ { a: 1, b: 1 }, { a: 2, b: 2 }, { b: 3, c: 3 }, { b: 4, c: 4 } ], engine.create, function () {
           engine.find({}, { fields: { b: 1, c: 1 }, limit: 1 }, function (error, objects) {

--- a/test/find.js
+++ b/test/find.js
@@ -185,6 +185,18 @@ module.exports = function(idProperty, getEngine) {
       })
     })
 
+    it('should support { limit: {} } property in options', function (done) {
+      getEngine(function (error, engine) {
+        async.map([ { a: 1, b: 1 }, { a: 2, b: 2 }, { b: 3, c: 3 }, { b: 4, c: 4 } ], engine.create, function () {
+          engine.find({}, { fields: { b: 1, c: 1 }, limit: 1 }, function (error, objects) {
+            objects.map(function(object) { delete object._id; return object })
+              .should.eql([ { b: 1 } ])
+            done()
+          })
+        })
+      })
+    })
+
     it('should return array of all objects for an empty query {} when there are no options', function (done) {
       getEngine(function (error, engine) {
         async.map([ { a: 1 }, { a: 1 }, { a: 1 }, { b: 1 } ], engine.create, function () {


### PR DESCRIPTION
The Mingo engine supports `.limit(n)` on the cursor, so pass through the limit option if provided.