### PR TITLE
Fix mingo version so that yarn doesn't upgrade it

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "async": "^2.4.1",
     "event-stream": "^3.3.4",
     "lodash.assign": "^4.2.0",
-    "mingo": "^1.1.2"
+    "mingo": "1.1.2"
   },
   "devDependencies": {
     "istanbul": "^0.4.5",


### PR DESCRIPTION
Mingo introduced a breaking change in v1.3.0 (removing the Mingo.setup
method). This causes failures when installing save via mongo when no
yarn.lock is present.

This project uses the new npm 5 package-lock.json, this is not supported
by yarn and so mingo gets silently upgraded from 1.1.2 to 1.3.0. It is
likely that this project will need to upgrade to the mingo 1.3.0 API,
but in the meantime this commit will ensure that 1.1.2 gets installed
when using yarn.

https://github.com/yarnpkg/yarn/issues/3614